### PR TITLE
Change git clone URL to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Desktop version: ([download](https://github.com/irislib/iris-electron/releases),
 
 ## Develop
 ```
-git clone git@github.com:irislib/iris-messenger.git
+git clone https://github.com/irislib/iris-messenger.git
 cd iris-messenger
 yarn
 yarn start


### PR DESCRIPTION
The current URL doesn't work if you don't have an SSH key uploaded to Github (as I just discovered cloning this onto a new machine). The https URL should work for more people.