### PR TITLE
Fix port, run server with npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn
 yarn start
 ```
 
-No build tools! It just serves the `src` directory at http://localhost:8000
+No build tools! It just serves the `src` directory at http://localhost:8080
 
 Eslint: `yarn eslint src/js/*.js --fix;yarn eslint src/js/components/*.js --fix`
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "http-server": "^0.12.1"
   },
   "scripts": {
-    "start": "echo 'Iris: http://localhost:8080'; http-server src --silent"
+    "start": "echo 'Iris: http://localhost:8080'; npx http-server src --silent"
   }
 }


### PR DESCRIPTION
- Default port of http-server is 8080, updating in README.
- Run http-server with npx so you don't need it installed globally.