### PR TITLE
Create infinite scroll

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -294,7 +294,6 @@ img, video {
 }
 
 .main > div {
-  overflow-y: scroll;
   display: flex;
   flex-direction: column;
 }
@@ -968,6 +967,32 @@ hr {
   border: none !important;
 }
 
+.loading-ring,
+.loading-ring:after {
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+}
+.loading-ring {
+  margin: 30px auto;
+  font-size: 10px;
+  position: relative;
+  text-indent: -9999em;
+  border-top: 6px solid rgba(0,0,0, 0.2);
+  border-right: 6px solid rgba(0,0,0, 0.2);
+  border-bottom: 6px solid rgba(0,0,0, 0.2);
+  border-left: 6px solid #000000;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: loading-ring-animation 1.1s infinite linear;
+  animation: loading-ring-animation 1.1s infinite linear;
+}
+
+.loading-ring__helper {
+  height: 5px;
+}
+
 .identicon-image {
   border-radius: 50%;
 }
@@ -1569,5 +1594,26 @@ form.public {
 @media (min-width: 576px) {
   .visible-xs-block, .visible-xs-inline-block, .visible-xs-flex {
     display: none !important;
+  }
+}
+
+@-webkit-keyframes loading-ring-animation {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+@keyframes loading-ring-animation {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }

--- a/src/js/components/MessageFeed.js
+++ b/src/js/components/MessageFeed.js
@@ -3,10 +3,9 @@ import { createRef } from '../lib/preact.js';
 import Helpers, { html } from '../Helpers.js';
 import PublicMessage from './PublicMessage.js';
 import ScrollWindow from '../lib/ScrollWindow.js';
-import State from '../State.js';
+// import State from '../State.js';
 
 class MessageFeed extends Component {
-  loadingRef = createRef();
   constructor() {
     super();
     this.state = {
@@ -17,6 +16,7 @@ class MessageFeed extends Component {
       size: 5,
       sizeIncrement: 5,
     };
+    this.loadingRef = createRef();
   }
   
   componentDidMount() {
@@ -37,7 +37,7 @@ class MessageFeed extends Component {
     this.observer.observe(this.loadingRef.current);
   }
 
-  handleObserver(entities, observer) {
+  handleObserver(entities) {
     const y = entities[0].boundingClientRect.y;
     if (this.state.prevY > y) {
       const curPage = this.state.size + this.state.sizeIncrement;


### PR DESCRIPTION
The initial amount of posts can be customized in the 'size' property of the component's state. (line 16)

The increment size of posts in each loading can also be customized there. (line 17)

There's still one thing I'll still do:

- [ ]  - Don't show loading spinner when all posts are loaded.

I removed line 297 of style.css to remove the duplicated scroll bar
![image](https://user-images.githubusercontent.com/25157126/106141695-3e45bb00-614f-11eb-8c75-bf3c33bb9f43.png)
