### PR TITLE
Add meaningful UI for empty contact list

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1595,6 +1595,12 @@ form.public {
   display: none;
 }
 
+.no-contacts-placeholder {
+  text-align: center;
+  font-size: 20px;
+  color: rgba(0,0,0,0.5)
+}
+
 .profile-link-container {
   margin-bottom: 15px;
   display: flex;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1595,12 +1595,6 @@ form.public {
   display: none;
 }
 
-.no-contacts-placeholder {
-  text-align: center;
-  font-size: 20px;
-  color: rgba(0,0,0,0.5)
-}
-
 .profile-link-container {
   margin-bottom: 15px;
   display: flex;

--- a/src/js/Translations.js
+++ b/src/js/Translations.js
@@ -140,6 +140,7 @@ export default {
     or_small: "or",
     automatically_load_webtorrent_attachments: "Automatically load webtorrent attachments",
     autoplay_webtorrent_videos: "Autoplay webtorrent videos",
+    no_contacts_in_list: 'You don\'t have any contacts in your list.',
 
   },
    "es": {
@@ -241,6 +242,7 @@ export default {
     call_ended: "Llamada finalizada",
     calling: "Llamando",
     on_call_with: "En comunicación con",
+    no_contacts_in_list: 'No tienes ningún contacto en tu lista.',
   },
   "pt-BR": {
     language_name: "Português Brasil",
@@ -341,6 +343,7 @@ export default {
     call_ended: "Chamada encerrada",
     calling: "Chamando",
     on_call_with: "Em chamada com",
+    no_contacts_in_list: 'Você não tem nenhum contato na sua lista.'
   },
 "ru": {
     language_name: "Русский",
@@ -788,6 +791,7 @@ export default {
     call_ended: "Chiamata conclusa",
     calling: "Chiamata in corso",
     on_call_with: "In chiamata con",
+    no_contacts_in_list: 'Non hai contatti nella tua lista.',
   },
   "zh-cn":{
     language_name: "中文",

--- a/src/js/views/Contacts.js
+++ b/src/js/views/Contacts.js
@@ -45,7 +45,7 @@ class Contacts extends View {
     if (keys.length === 0) {
       return html`
       <div class="centered-container">
-        <div class="no-contacts-placeholder">${t('no_contacts_in_list')}</div>
+        ${t('no_contacts_in_list')}
       </div>
       `
     }

--- a/src/js/views/Contacts.js
+++ b/src/js/views/Contacts.js
@@ -42,6 +42,13 @@ class Contacts extends View {
 
   renderView() {
     const keys = Object.keys(this.contacts);
+    if (keys.length === 0) {
+      return html`
+      <div class="centered-container">
+        <div class="no-contacts-placeholder">${t('no_contacts_in_list')}</div>
+      </div>
+      `
+    }
     keys.sort((a,b) => {
       const aF = this.contacts[a].followers && this.contacts[a].followers.size || 0;
       const bF = this.contacts[b].followers && this.contacts[b].followers.size || 0;


### PR DESCRIPTION
Before, when you have no contacts in your list, the Contacts page
is empty with some dangling lodash on the screen making it look broken.

Moving forward, it will display a meaningful message for the user.

![image](https://user-images.githubusercontent.com/6699184/125048701-4f2e2b80-e0f4-11eb-975c-e99990a91b14.png)
