### PR TITLE
docs: do not bury the lede in the Privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ yarn test
 ```
 
 ## Privacy
+The application is an unaudited proof-of-concept implementation, so don't use it for security critical purposes.
+
 Private messages are end-to-end encrypted, but message timestamps and the number of chats aren't. In a decentralized network this information is potentially available to anyone.
 
 By looking at timestamps in chats, it is possible to guess who are chatting with each other. It is also possible, if not trivial, to find out who are communicating with each other by monitoring data subscriptions on the decentralized database.
@@ -46,8 +48,6 @@ By looking at timestamps in chats, it is possible to guess who are chatting with
 In that regard, Iris prioritizes decentralization and availability over perfect privacy.
 
 Profile names, photos and online status are currently public. That can be changed when advanced group permissions are developed.
-
-The application is an unaudited proof-of-concept implementation, so don't use it for security critical purposes.
 
 ## Contact
 Join our [Discord](https://discord.gg/4Dgf54k) or send me a message on [Iris](https://iris.to/?chatWith=hyECQHwSo7fgr2MVfPyakvayPeixxsaAWVtZ-vbaiSc.TXIp8MnCtrnW6n2MrYquWPcc-DTmZzMBmc2yaGv9gIU&s=HlzYzNrhUsrn2PLi4yuRt6DiFUNM3hOmN8nFpgw6T-g&k=zvDfsInsMOI1).

--- a/src/js/views/About.js
+++ b/src/js/views/About.js
@@ -53,13 +53,13 @@ class About extends View {
         `}
 
         <h4>Privacy</h4>
+        <p>${t('application_security_warning')}</p>
         <p>Private messages are end-to-end encrypted, but message timestamps and the number of chats aren't. In a decentralized network this information is potentially available to anyone.</p>
         <p>By looking at timestamps in chats, it is possible to guess who are chatting with each other. There are potential technical solutions to hiding the timestamps, but they are not implemented yet. It is also possible, if not trivial, to find out who are communicating with each other by monitoring data subscriptions on the decentralized database.</p>
         <p>In that regard, Iris prioritizes decentralization and availability over perfect privacy.</p>
         <p>Profile names, photos and online status are currently public. That can be changed when advanced group permissions are developed.</p>
         <p>Iris makes no guarantees of data persistence.</p>
         <p>You can check your saved data in the <a href="/explorer">Explorer</a>.</p>
-        <p>${t('application_security_warning')}</p>
 
         <h4>Developer:</h4>
         <div class="profile-link-container">


### PR DESCRIPTION
The disclaimer about iris-messenger not being ready for security-critical purposes is the most important part of the Privacy section. This change moves it to the top of the section.