### PR TITLE
Improve the quoted message UI and new / reply message form

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -776,9 +776,27 @@ header.footer .header-content {
 }
 
 .quote .msg-content {
-  background-color: rgba(0,0,0,0.05);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: #808080;
   padding: 7px 15px !important;
 }
+
+.quote .identicon-container.has-picture {
+  max-width: 30px;
+  max-height: 30px;
+}
+
+.public-messages-view .quote .msg-sender {
+  margin-bottom: 8px;
+}
+
+.msg:not([class*="quote"]) > div.msg-content > div.msg-sender,
+.msg:not([class*="quote"]) > div.msg-content > div.text,
+.msg:not([class*="quote"]) > div.msg-content > div.below-text
+{
+    margin-left: 1em;
+}
+
 
 .reply .msg-content {
   box-shadow: none;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -239,6 +239,10 @@ video {
   margin-left: 5px;
 }
 
+textarea.new-msg {
+  border: 2px solid #8473b3;
+}
+
 .filters .msg-content {
   flex-direction: row !important;
   padding: 15px;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1984,10 +1984,40 @@ button {
   cursor: pointer;
 }
 
-form.public button {
+.message-form .public-messages-view .msg .msg-content,
+.message-form textarea.new-msg {
+  margin-right: auto;
+  margin-left: auto;
+  display: block;
+  height: 10em;
+}
+form.public button[type='submit'] {
   height: 47px;
   width: 47px;
   margin-right: 5px;
+  border-radius: 5px;
+  background-color: #8473b3;
+  color: #FFF;;
+}
+
+form.public button[type='submit'] span {
+  display: inline;
+  font-size: 0.8em;
+}
+
+form.public button[type='submit'] {
+  float: right;
+  right: 0;
+  clear: both;
+}
+
+form.public button[type='submit'] span {
+  display: none;
+}
+
+.msg-content form.public button[type='submit'] svg {
+  position: relative;
+  top: -32px;
 }
 
 form.public button:last-of-type {
@@ -2007,13 +2037,11 @@ form.public div {
   position: relative;
 }
 
-form.public button[type='submit'] {
-  position: absolute;
-  right: 0;
-}
-
 form.public {
+  width: 100%;
   margin-bottom: 15px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .retrieving {
@@ -2429,10 +2457,7 @@ input[type='text'] {
   .main-view.public-messages-view .centered-container > h3 {
     padding-left: 15px;
   }
-  .public-messages-view .msg .msg-content,
-  textarea {
-    border-radius: 0 !important;
-  }
+
   .public-messages-view .img-container,
   .torrent {
     margin-left: -15px;
@@ -2446,9 +2471,22 @@ input[type='text'] {
   .profile-top {
     padding: 10px 15px;
   }
-  form.public div {
-    margin: 0 15px;
+
+  div:not([class*="msg-content"]) > form.public {
+    width: 94%;
   }
+  
+  div:not([class*="msg-content"]) > form.public button[type='submit'] {
+    display: block;
+    width: 100%;
+  }
+  
+  div:not([class*="msg-content"]) > form.public button[type='submit'] span {
+    display: inline;
+  }
+  /* form.public div {
+    margin: 0 10px;
+  } */
   .nav .search-box input {
     width: 90%;
   }

--- a/src/js/components/PublicMessage.js
+++ b/src/js/components/PublicMessage.js
@@ -442,7 +442,7 @@ class PublicMessage extends Message {
           <div class="msg-sender">
             <div class="msg-sender-link" onclick=${() => this.onClickName()}>
               ${s.msg.info.from ? html`<${Identicon} str=${s.msg.info.from} width="40" />` : ''}
-              ${name && this.props.showName && html`<small class="msgSenderName">${name}</small>`}
+              ${name && this.props.showName && html`<div class="msgSenderName">${name}</div>`}
             </div>
             ${this.renderDropdown()}
           </div>

--- a/src/js/views/Notifications.js
+++ b/src/js/views/Notifications.js
@@ -64,7 +64,7 @@ export default class Notifications extends View {
                 <div class="msg-sender">
                   <a class="msg-sender-link" href="/profile/${notification.from}">
                     <${Identicon} str=${notification.from} width="30" />${' '}
-                    <small class="msgSenderName"><${Name} pub=${notification.from} /></small>
+                    <div class="msgSenderName"><${Name} pub=${notification.from} /></div>
                   </a>
                 </div>
                 ${notification.text || ''}


### PR DESCRIPTION
I think that the quoted message UI can be improved a bit. For me is not always easy to pick up the main message against the quoted one. Proposal:

* Lower the contrast prominence of the quoted message
* Fix the vertical alignment

Actual rendering:

<img width="670" alt="actual" src="https://user-images.githubusercontent.com/89577423/211099299-3a11e11a-ae55-4213-8ed3-6690dba7755e.png">

Proposed:

<img width="670" alt="proposed" src="https://user-images.githubusercontent.com/89577423/211099321-cb47d23d-2400-46ea-a87f-74989e345af6.png">

PS: I took the chance to reset the sender name font size because the profile image anyway takes some space, is not useful to reduce the text size.
