### PR TITLE
Improve new post UX on mobile

### DIFF
--- a/src/js/components/FeedMessageForm.js
+++ b/src/js/components/FeedMessageForm.js
@@ -219,6 +219,7 @@ class FeedMessageForm extends MessageForm {
           </svg>
         </button>
         <button type="submit">
+          <span>${t('send_message')} </span>
           <svg
             class="svg-inline--fa fa-w-16"
             x="0px"

--- a/src/js/components/FeedMessageForm.js
+++ b/src/js/components/FeedMessageForm.js
@@ -24,7 +24,10 @@ class FeedMessageForm extends MessageForm {
       textEl.val(textEl.val() + emoji);
       textEl.focus();
     });
-    if (!iris.util.isMobile && this.props.autofocus !== false) {
+    if (
+      (!iris.util.isMobile || this.props.forceAutofocusMobile == true) &&
+      this.props.autofocus !== false
+    ) {
       textEl.focus();
     }
     if (!this.props.replyingTo) {

--- a/src/js/components/PublicMessage.js
+++ b/src/js/components/PublicMessage.js
@@ -541,7 +541,10 @@ class PublicMessage extends Message {
                   >
                     ${s.liked ? Icons.heartFull : Icons.heartEmpty}
                   </a>
-                  <span class="count" onClick=${() => this.setState({ showLikes: !s.showLikes, showBoosts: false })}>
+                  <span
+                    class="count"
+                    onClick=${() => this.setState({ showLikes: !s.showLikes, showBoosts: false })}
+                  >
                     ${s.likes || ''}
                   </span>
                   <a
@@ -550,7 +553,10 @@ class PublicMessage extends Message {
                   >
                     ${Icons.boost}
                   </a>
-                  <span class="count" onClick=${() => this.setState({ showBoosts: !s.showBoosts, showLikes: false })}>
+                  <span
+                    class="count"
+                    onClick=${() => this.setState({ showBoosts: !s.showBoosts, showLikes: false })}
+                  >
                     ${s.boosts || ''}
                   </span>
                 `}

--- a/src/js/views/Message.js
+++ b/src/js/views/Message.js
@@ -25,7 +25,12 @@ class Message extends View {
     let content;
     if (this.props.hash === 'new') {
       content = html`
-        <${FeedMessageForm} activeChat="public" autofocus=${true} onSubmit=${() => route('/')} />
+        <${FeedMessageForm}
+          activeChat="public"
+          forceAutofocusMobile=${true}
+          autofocus=${true}
+          onSubmit=${() => route('/')}
+        />
       `;
     } else {
       content = html`


### PR DESCRIPTION
Little touches to improve the UX on mobile on posting a new note:

* Add a caption to the send button for new posts on mobile, missing file from pull request #176: the mobile button is ok full screen for usability, let's add some text make it clear what it does.
@mmalmi perhaps could be better to add a new text/translation "Post public note" instead of "Send message"?

* Fix the autofocus for new post form on mobile: on mobile when the user click the (+) icon the text area is the only and main element, so is ok to focus it and open the keyboard.

PS: My React skills are zero, so feel free to tweak the code!
PPS: This a duplicate of the closed [#178](https://github.com/irislib/iris-messenger/pull/178).