### PR TITLE
Remove the useless space on the right of the quoted message

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -775,10 +775,6 @@ header.footer .header-content {
   flex: none;
 }
 
-.quote {
-  padding-right: 15px;
-}
-
 .quote .msg-content {
   background-color: rgba(255, 255, 255, 0.05);
   color: #808080;


### PR DESCRIPTION
From:

<img width="359" alt="before" src="https://user-images.githubusercontent.com/89577423/211222921-4d001f53-accf-4252-ba94-2f20c7a992dc.png">

To:

<img width="359" alt="after" src="https://user-images.githubusercontent.com/89577423/211222925-dbc2cee1-f40e-41e4-b28a-dc4f6cb8bcb6.png">
