### PR TITLE
make iris pinch scalable on mobile

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -6,10 +6,7 @@
 
     <base href="./" />
     <meta name="description" content="Social Networking Freedom" data-react-helmet="true" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="iris" data-react-helmet="true" />
     <meta property="og:description" content="Social Networking Freedom" data-react-helmet="true" />
     <meta property="og:url" content="https://iris.to" data-react-helmet="true" />


### PR DESCRIPTION
Hi, just stumbled upon this.

This change allows scalable two finger pinch zoom on mobile,
there are a lot of good graphical content with high res and detail. but iris was not able on
mobile to zoom in.

I tested this patch with a local clone on a Tor instance over torbrowser and on firefox and chrome , and all click buttons, and functions worked so far, even when zoomed.

The whole app feel is now way more *mobile* feel, and all your magic work like charm