### PR TITLE
Stop sending empty kind:6 events. use kind:1 with a reference instead.

### DIFF
--- a/src/js/components/PublicMessage.js
+++ b/src/js/components/PublicMessage.js
@@ -219,11 +219,12 @@ class PublicMessage extends Message {
       const nostrId = Nostr.toNostrHexAddress(this.props.hash);
       if (nostrId) {
         Nostr.publish({
-          kind: 6,
+          kind: 1,
           tags: [
             ['e', nostrId],
             ['p', author],
           ],
+          content: '#[0]',
         });
       }
     }


### PR DESCRIPTION
Empty kind 6 events were a wrong NIP, no one implements them.

https://github.com/nostr-protocol/nips/blob/master/10.md has a safer way to "retweet" that most clients implement.