### PR TITLE
fix: subscription to `new`

### DIFF
--- a/src/js/Nostr.ts
+++ b/src/js/Nostr.ts
@@ -1357,8 +1357,9 @@ const Nostr = {
       this.knownUsers.add(hex);
       this.getProfile(this.toNostrHexAddress(hex), undefined);
     }
-    this.sendSubToRelays([{ kinds: [0, 1, 3, 6, 7], limit: 200 }], 'new'); // everything new
+
     setTimeout(() => {
+      this.sendSubToRelays([{ kinds: [0, 1, 3, 6, 7], limit: 200 }], 'new'); // everything new
       this.sendSubToRelays([{ authors: [key.secp256k1.rpub] }], 'ours'); // our stuff
       this.sendSubToRelays([{ '#p': [key.secp256k1.rpub] }], 'notifications'); // notifications and DMs
     }, 200);


### PR DESCRIPTION
The subscription to `everything new` was lost for some reason.

Sometimes it worked when multiple relays are configured, but when only one relay is used new events are not handled (although the relay sends them correctly)

The solution follows the  `our stuff` and `notifications and DMs` approach and delays the subscription.