### PR TITLE
Stop to subscribe global event always.

### DIFF
--- a/src/js/Nostr.ts
+++ b/src/js/Nostr.ts
@@ -1358,7 +1358,7 @@ const Nostr = {
     }
 
     setTimeout(() => {
-      this.sendSubToRelays([{ kinds: [0, 1, 3, 6, 7], limit: 200 }], 'new'); // everything new
+      this.sendSubToRelays([{ kinds: [0, 1, 3, 6, 7], limit: 200 }], 'new', true); // everything new
       this.sendSubToRelays([{ authors: [key.secp256k1.rpub] }], 'ours'); // our stuff
       this.sendSubToRelays([{ '#p': [key.secp256k1.rpub] }], 'notifications'); // notifications and DMs
     }, 200);


### PR DESCRIPTION
Iris always receives global events regardless of opening the global page or not.

```
{"kinds":[0,1,3,6,7],"limit":200}
```

This request will always recieve large traffic depending on relay server: relay.damus.io.
This is serious with mobile line.
Iris should CLOSE when it receives an EOSE from the relay.