### PR TITLE
Set t-tag when send message

### DIFF
--- a/src/js/Helpers.tsx
+++ b/src/js/Helpers.tsx
@@ -17,6 +17,7 @@ const emojiRegex =
   /([\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]+)/gu;
 const pubKeyRegex = /(?:^|\s)((?:@)?npub[a-zA-Z0-9]{59,60})(?![\w/])/gi;
 const noteRegex = /(?:^|\s)((?:@)?note[a-zA-Z0-9]{59,60})(?![\w/])/gi;
+const hashtagRegex = /(#\w+)/g;
 
 let settings: any = {};
 iris
@@ -343,7 +344,7 @@ export default {
     }
 
     // highlight hashtags, link to /search/${encodeUriComponent(hashtag)}
-    s = reactStringReplace(s, /(#\w+)/g, (match) => {
+    s = reactStringReplace(s, hashtagRegex, (match) => {
       return <a href={`/search/${encodeURIComponent(match.slice(1))}`}>{match}</a>;
     });
 
@@ -530,4 +531,5 @@ export default {
   isElectron,
   pubKeyRegex,
   noteRegex,
+  hashtagRegex,
 };

--- a/src/js/components/MessageForm.js
+++ b/src/js/components/MessageForm.js
@@ -56,6 +56,17 @@ export default class MessageForm extends Component {
 
     handleTagged(Helpers.pubKeyRegex, 'p');
     handleTagged(Helpers.noteRegex, 'e');
+
+    const hashtags = [...msg.text.matchAll(Helpers.hashtagRegex)].map((m) => m[0].slice(1));
+    if (hashtags.length) {
+      event.tags = event.tags || [];
+      for (const hashtag of hashtags) {
+        if (!event.tags.find((t) => t[0] === 't' && t[1] === hashtag)) {
+          event.tags.push(['t', hashtag]);
+        }
+      }
+    }
+
     console.log('sending event', event);
     return Nostr.publish(event);
   }


### PR DESCRIPTION
Hello, iris!

To implove searchability of message, I want to set [t(topic)-tag](https://github.com/nostr-protocol/nips/blob/master/12.md#suggested-use-cases) in message when send it.
So, I changed message sending process to extract `#`-prefixed format string(e.g. `#hashtagOrTopic`) in content and set it as t-tag.

Please review at your convenience.
