### PR TITLE
fix notification name link to profile instead of note

### DIFF
--- a/src/js/components/PublicMessage.js
+++ b/src/js/components/PublicMessage.js
@@ -364,6 +364,7 @@ class PublicMessage extends Message {
     } else {
       text = Helpers.highlightText(text, likedEvent);
     }
+    const profileLink = `/${Nostr.toNostrBech32Address(this.state.msg?.event?.pubkey, 'npub')}`;
     const link = `/post/${Nostr.toNostrBech32Address(likedId, 'note')}`;
     return html`
       <div class="msg">
@@ -372,7 +373,7 @@ class PublicMessage extends Message {
             style="display: flex; align-items: center; flex-basis: 100%; white-space: nowrap;text-overflow: ellipsis; overflow:hidden"
           >
             <i class="like-btn liked" style="margin-right: 15px;"> ${Icons.heartFull} </i>
-            <a href=${link} style="margin-right: 5px;">
+            <a href=${profileLink} style="margin-right: 5px;">
               <${Name} pub=${this.state.msg?.event?.pubkey} userNameOnly=${true} />
             </a>
             <span>


### PR DESCRIPTION
User name link in notifications was a link to notes, fixed to profile.(deepl)


https://github.com/irislib/iris-messenger/commit/ffbbc72927d07299f2d421612fa0e10f5364a530#diff-e852a36f3e33581d2eb87cd3782ce282a23d885600dbf9dc0615caa86655d316