### PR TITLE
add onClick prop to SafeImg explicitly

### DIFF
--- a/src/js/components/SafeImg.tsx
+++ b/src/js/components/SafeImg.tsx
@@ -5,6 +5,8 @@ type Props = {
   class?: string;
   width?: number;
   onError?: () => void;
+  onClick?: (ev: MouseEvent) => void;
+  alt?: string;
 };
 
 // need to have trailing slash, otherwise you could do https://imgur.com.myevilwebsite.com/image.png
@@ -51,7 +53,16 @@ const SafeImg = (props: Props) => {
   }
   const [src, setSrc] = useState(mySrc);
 
-  return <img src={src} onError={onError} className={props.class} width={props.width} />;
+  return (
+    <img
+      src={src}
+      onError={onError}
+      onClick={props.onClick}
+      className={props.class}
+      width={props.width}
+      alt={props.alt}
+    />
+  );
 };
 
 export default SafeImg;


### PR DESCRIPTION
fixed that l.53 in 9072d0d3142039e01f858b3e9e6420da6112b890 broke [`openAttachmentsGallery()` calling](https://github.com/irislib/iris-messenger/blob/47ea993daa4f0456dc9935b38ff5adce97b3cf13/src/js/components/PublicMessage.js#L708)