### PR TITLE
fix: wrongly shaped identicons

### DIFF
--- a/src/js/components/Identicon.tsx
+++ b/src/js/components/Identicon.tsx
@@ -104,7 +104,7 @@ class MyIdenticon extends Component<Props, State> {
             <SafeImg
               src={this.state.picture}
               width={width}
-              style={{ objectFit: 'contain' }}
+              style={{ objectFit: 'cover' }}
               onError={() => this.setState({ hasError: true })}
             />
           ) : (

--- a/src/js/components/Identicon.tsx
+++ b/src/js/components/Identicon.tsx
@@ -92,14 +92,6 @@ class MyIdenticon extends Component<Props, State> {
     const hasPictureStyle = hasPicture ? 'has-picture' : '';
     const showTooltip = this.props.showTooltip ? 'tooltip' : '';
 
-    const pictureElement = (
-      <SafeImg
-        src={this.state.picture}
-        width={width}
-        onError={() => this.setState({ hasError: true })}
-      />
-    );
-
     return (
       <IdenticonContainer
         width={width}
@@ -107,8 +99,17 @@ class MyIdenticon extends Component<Props, State> {
         style={{ cursor: this.props.onClick ? 'pointer' : undefined }}
         className={`identicon-container ${hasPictureStyle} ${showTooltip} ${activity}`}
       >
-        <div style={{ width: width, height: width }} class="identicon">
-          {hasPicture ? pictureElement : <img width={width} src={this.state.identicon} />}
+        <div style={{ width: `${width}px`, height: `${width}px` }} class="identicon">
+          {hasPicture ? (
+            <SafeImg
+              src={this.state.picture}
+              width={width}
+              style={{ objectFit: 'contain' }}
+              onError={() => this.setState({ hasError: true })}
+            />
+          ) : (
+            <img width={width} src={this.state.identicon} />
+          )}
         </div>
         {this.props.showTooltip && this.state.name ? (
           <span class="tooltiptext">{this.state.name}</span>

--- a/src/js/components/SafeImg.tsx
+++ b/src/js/components/SafeImg.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 type Props = {
   src: string;
   class?: string;
+  style?: React.CSSProperties;
   width?: number;
   onError?: () => void;
   onClick?: (ev: MouseEvent) => void;
@@ -59,7 +60,9 @@ const SafeImg = (props: Props) => {
       onError={onError}
       onClick={props.onClick}
       className={props.class}
+      style={props.style}
       width={props.width}
+      height={props.width}
       alt={props.alt}
     />
   );


### PR DESCRIPTION
profiles like this one with a large profile picture, show a large oval instead of the regular circle pfp: https://iris.to/npub1y73qksdxdv6ags3s9fgv5xa26ukzakzyergjynyld4g2zf6jpp8q45htck

the problem was ` style={{ width: width, height: width }}` is an invalid value, since the correct is using the `px` suffix `style={{ width: '${width}px', height: '${width}px' }}`, also there's no point declaring the `<SafeImg>` component at the middle of render, also added `style={{ objectFit: 'contain' }}` to make the full large picture fit inside the smaller size