### PR TITLE
Improved lightning link regex

### DIFF
--- a/src/js/Helpers.tsx
+++ b/src/js/Helpers.tsx
@@ -263,7 +263,7 @@ export default {
     replacedText = this.highlightText(replacedText, event, opts);
 
     const lnRegex =
-      /(lightning:[\w.-]+@[\w.-]+|lightning:\w+\?amount=\d+|(?:lightning:)?(?:lnurl|lnbc)[\da-z0-9]+)/gi;
+      /(lightning:[\w.-]+@[\w.-]+|lightning:\w+\?amount=\d+|(?:lightning:)?(?:lnurl1|lnbc1)[\da-z0-9]+)/gi;
     replacedText = reactStringReplace(replacedText, lnRegex, (match) => {
       if (!match.startsWith('lightning:')) {
         match = `lightning:${match}`;


### PR DESCRIPTION
Fixes #286 

All bech32 prefixes end in a `1` so by including the `1` in the regex we can differentiate real LNURLs from mentions of the word LNURL.