### PR TITLE
Optimized Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM ubuntu:22.04
-RUN apt update -yq
-RUN DEBIAN_FRONTEND=noninteractive apt install -yq aptitude emacs-nox screen rsync build-essential curl git jq
-RUN DEBIAN_FRONTEND=noninteractive apt purge -yq cmdtest nodejs
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN DEBIAN_FRONTEND=noninteractive apt install -yq nodejs
-RUN npm install --global yarn
-COPY . iris-messenger
-RUN (cd iris-messenger && yarn)
-RUN (cd iris-messenger && NODE_OPTIONS=--openssl-legacy-provider yarn build)
-RUN (cd iris-messenger && cat package.json | jq '.scripts.serve="sirv build --host 0.0.0.0 --port 8080 --cors --single"' > package.json.new && mv -vf package.json.new package.json)
+FROM node:19-buster-slim
+RUN apt-get update && apt-get install -yq git jq
+COPY . /iris-messenger
+WORKDIR /iris-messenger/
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
-CMD bash -c "(cd iris-messenger && NODE_OPTIONS=--openssl-legacy-provider yarn serve)"
+RUN yarn
+RUN yarn build
+RUN cat package.json | jq '.scripts.serve="sirv build --host 0.0.0.0 --port 8080 --cors --single"' > package.json.new && mv -vf package.json.new package.json
+
+CMD [ "yarn", "serve" ]
 


### PR DESCRIPTION
Use `node` image as base, this eliminates the node/yarn installation steps (speeding up the build) and results in a smaller image than with ubuntu base image.