### PR TITLE
ensure relay URL includes a protocol ("://"), else prefix wss://

### DIFF
--- a/src/js/views/settings/NetworkSettings.jsx
+++ b/src/js/views/settings/NetworkSettings.jsx
@@ -19,10 +19,17 @@ const NetworkSettings = () => {
     Nostr.removeRelay(relay.url);
   };
 
+  const ensureProtocol = (relay) => {
+    if (relay.includes('://')) return relay
+
+    return `wss://${relay}`
+  }
+
   const handleAddRelay = (event) => {
-    iris.local().get('relays').get(newRelayUrl).put({ enabled: true });
+    const newRelayUrlWithProtocol = ensureProtocol(newRelayUrl);
+    iris.local().get('relays').get(newRelayUrlWithProtocol).put({ enabled: true });
     event.preventDefault(); // prevent the form from reloading the page
-    Nostr.addRelay(newRelayUrl); // add the new relay using the Nostr method
+    Nostr.addRelay(newRelayUrlWithProtocol); // add the new relay using the Nostr method
     setNewRelayUrl(''); // reset the new relay URL
   };
 


### PR DESCRIPTION
Title says it all. Trying to scratch my own itch here, since I often forget the "wss://".

Kept PR as small as possible. Other cleaning of the relay URL would also be thinkable here, e.g. trim, remove trailing slash, etc..

Please advise if you think it is useful at all and whether you would like me to implement it differently.