### PR TITLE
e tag for zap could be undefined

### DIFF
--- a/src/js/components/PublicMessage.js
+++ b/src/js/components/PublicMessage.js
@@ -416,7 +416,7 @@ class PublicMessage extends Message {
   }
 
   renderZap() {
-    const likedId = this.state.msg.event.tags?.reverse().find((t) => t[0] === 'e')[1];
+    const likedId = this.state.msg.event.tags?.reverse().find((t) => t[0] === 'e')?.[1];
     const likedEvent = Events.cache.get(likedId);
     let text = likedEvent?.content;
     if (text && text.length > 50) {


### PR DESCRIPTION
I don't make sure why this happended but probably zap notification could have tags that does not have e tag.

```
Uncaught TypeError: Cannot read properties of undefined (reading '1')
    at ge.renderZap (PublicMessage.js:419:72)
    at ge.render (PublicMessage.js:610:21)
    at _ (index.js:192:13)
    at component.js:132:3
    at Array.some (<anonymous>)
    at d (component.js:211:9)
```