### PR TITLE
Add Wavlake embedded player

### DIFF
--- a/src/js/Helpers.tsx
+++ b/src/js/Helpers.tsx
@@ -312,6 +312,25 @@ export default {
       });
     }
 
+    // wavlake track/album/artist
+    if (settings.enableWavlake !== false) {
+      const wavlakeRegex =
+        /https:\/\/player\.wavlake\.com\/(?!feed\/|artists)(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;
+      replacedText = reactStringReplace(replacedText, wavlakeRegex, (match, i) => {
+        return (
+          <iframe
+            key={match + i}
+            height="380"
+            width="100%"
+            style={{ maxWidth: '100%' }}
+            src={`https://embed.wavlake.com/${match}`}
+            frameBorder="0"
+            loading="lazy"
+          />
+        );
+      });
+    }
+
     if (settings.enableTorrent !== false) {
       const magnetRegex = /(magnet:\?xt=urn:btih:.*)/gi;
       replacedText = reactStringReplace(replacedText, magnetRegex, (match, i) => {

--- a/src/js/views/settings/Media.js
+++ b/src/js/views/settings/Media.js
@@ -23,6 +23,7 @@ export default class Media extends Component {
       { setting: 'enableSpotify', label: 'Spotify' },
       { setting: 'enableTidal', label: 'Tidal' },
       { setting: 'enableTwitch', label: 'Twitch' },
+      { setting: 'enableWavlake', label: 'Wavlake' },
     ];
     return (
       <>


### PR DESCRIPTION
This PR enables Wavlake track/album/artist links shared in Nostr notes to be rendered as a custom embedded player (see example screenshot). The player also supports boosting via invoices. The iframe has been defined with the minimum number of attributes needed -- wasn't sure if some of the others are preferred for iris but I thought I'd err on the minimal side for now.

Please let me know if you need any changes. Would love to see these shared links work on iris.

<img width="640" alt="Screenshot 2023-03-16 at 8 55 48 PM" src="https://user-images.githubusercontent.com/77257032/225792410-a64ea14d-9460-4d10-8ade-a4723798ffac.png">
