### PR TITLE
Wavlake: Update regex to support home domain links

### DIFF
--- a/src/js/Helpers.tsx
+++ b/src/js/Helpers.tsx
@@ -315,7 +315,7 @@ export default {
     // wavlake track/album/artist
     if (settings.enableWavlake !== false) {
       const wavlakeRegex =
-        /https:\/\/player\.wavlake\.com\/(?!feed\/|artists)(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;
+        /https:\/\/(?:player\.)?wavlake\.com\/(?!feed\/|artists)(track\/[.a-zA-Z0-9-]+|album\/[.a-zA-Z0-9-]+|[.a-zA-Z0-9-]+)/i;
       replacedText = reactStringReplace(replacedText, wavlakeRegex, (match, i) => {
         return (
           <iframe


### PR DESCRIPTION
We just updated our site so that the music player lives on wavlake.com. This update allows Iris to render embeds correctly for tracks/albums/artists from both the legacy player.wavlake.com links as well as the new ones.