### PR TITLE
update dockerfile to use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,39 @@
-FROM node:19-buster-slim
-RUN apt-get update && apt-get install -yq git jq python3 build-essential
-COPY . /iris-messenger
-WORKDIR /iris-messenger/
-ENV NODE_OPTIONS=--openssl-legacy-provider
+# Build Stage
+FROM node:19-buster-slim AS build-stage
 
+# Install tools
+RUN apt-get update \
+    && apt-get install -y git \
+    && apt-get install -y jq \
+    && apt-get install -y python3 \
+    && apt-get install -y build-essential
+
+# Create build directory
+WORKDIR /build
+
+# Copy package.json and yarn.lock
+COPY package.json yarn.lock ./
+
+# Install dependencies
+ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN yarn
-RUN yarn build
+
+# Copy project files and folders to the current working directory (i.e. '/app')
+COPY . .
+
+# Build app
 RUN cat package.json | jq '.scripts.serve="sirv build --host 0.0.0.0 --port 8080 --cors --single"' > package.json.new && mv -vf package.json.new package.json
+RUN yarn build
+
+# Final image
+FROM node:19-buster-slim
+
+# Change directory to '/app' 
+WORKDIR /app
+
+# Copy built code from build stage to '/app' directory
+COPY --from=build-stage /build .
+
+EXPOSE 8080
 
 CMD [ "yarn", "serve" ]
-


### PR DESCRIPTION
This PR updates the Dockerfile to use a multi-stage build to reduce the final image size, while also making subsequent builds faster by caching dependencies.

I have tested this Dockerfile on the `production` branch as of commit `a2de27cd`.  

Image here under `production-test` tag: https://hub.docker.com/repository/docker/nmfretz/iris-messenger/tags?page=1&ordering=last_updated