### PR TITLE
add workflow to build and push docker image on tag

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -1,0 +1,66 @@
+name: Docker build on tag
+env:
+  DOCKER_CLI_EXPERIMENTAL: enabled
+  TAG_FMT: '^refs/tags/(((.?[0-9]+){3,4}))$'
+
+on:
+  push:
+    tags:
+      - [0-9]+.[0-9]+.[0-9]+
+      - [0-9]+.[0-9]+.[0-9]+-*
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    name: Build and push iris-messenger image
+    steps:
+      - name: Set env variables
+        run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Show set environment variables
+        run: |
+          printf "    TAG: %s\n"  "$TAG"
+            
+      - name: Login to Docker for building
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        id: qemu
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Run Docker buildx against tag
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --platform linux/amd64,linux/arm64 \
+          --tag ${{ secrets.DOCKER_HUB_USER }}/iris-messenger:$TAG \
+          --output "type=registry" ./
+
+      - name: Run Docker buildx against latest
+        run: |
+          docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache" \
+          --platform linux/amd64,linux/arm64 \
+          --tag ${{ secrets.DOCKER_HUB_USER }}/iris-messenger:latest \
+          --output "type=registry" ./


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically build and push multi-arch (amd64 & arm64) Docker images to a Docker registry when a new git tag is pushed that matches the [Semantic Versioning](https://semver.org/) pattern. 

For example, this will build/push images when tags like `0.5.0`, `v0.6.1`, `0.2.1-beta`, etc are [pushed](https://stackoverflow.com/a/18223354). Two multi-arch images will be pushed to the Docker repository:
1) An image with a tag that is the same as the recently-pushed git tag (e.g., `irislib/iris-messenger:v1.0.0`)
2) An image with the `latest` tag (e.g., `irislib/iris-messenger:latest`)

Here are the GitHub secrets needed for this workflow (for the Docker registry credentials): https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`
- `DOCKER_HUB_USER`

This PR is based on this Umbrel workflow: https://github.com/getumbrel/umbrel-manager/blob/fc823490591ea55e26734d144a0527fe9618166d/.github/workflows/on-tag.yml