### PR TITLE
session: fix type error

### DIFF
--- a/src/js/nostr/Session.ts
+++ b/src/js/nostr/Session.ts
@@ -144,17 +144,6 @@ const Session = {
   init: function (options: any) {
     Key.getOrCreate(options);
     localState.get('loggedIn').on(() => this.onLoggedIn());
-    let lastResubscribed = Date.now();
-    document.addEventListener('visibilitychange', () => {
-      // when iris returns to foreground after 1 min dormancy, resubscribe stuff
-      // there might be some better way to manage resubscriptions?
-      if (document.visibilityState === 'visible') {
-        if (Date.now() - lastResubscribed > 60 * 1000 * 1) {
-          Relays.resubscribe();
-          lastResubscribed = Date.now();
-        }
-      }
-    });
   },
 };
 


### PR DESCRIPTION
Relaypool handles reconnects, so most likely this isn't required anymore.

`Relays.resubscribe()` no longer exists.