### PR TITLE
key: use nip19 identifiers everywhere

### DIFF
--- a/src/js/nostr/EventsMeta.ts
+++ b/src/js/nostr/EventsMeta.ts
@@ -15,6 +15,15 @@ class EventMetaStore {
     return this;
   }
 
+  upsertRelays(id: string, relays: string[] = []) {
+    if (relays.length === 0) {
+      return;
+    }
+    this.upsert(id, {
+      relays: new Set(relays),
+    });
+  }
+
   get(id: string): undefined | EventMetadata {
     if (!id) return;
     return this._data.get(id);


### PR DESCRIPTION
Changes links to point to `nprofile`/`nevent` rather than `npub`/`note`.

Changes to `src/js/lib/nostr-tools/nip19.ts` are copy paste from
nostr-tools library.