### PR TITLE
Don't hardcode port 8080 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "build": "preact build --no-prerender",
-    "serve": "sirv build --port 8080 --cors --single",
+    "serve": "sirv build --cors --single",
     "dev": "preact watch --host localhost --sw",
     "dev-docker": "preact watch --host 0.0.0.0 --sw",
     "lint": "eslint 'src/**/*.{js,ts,tsx}'",


### PR DESCRIPTION
When testing on a machine which already has something else running on port 8080, I got the following behavior when trying to manually set the port:

```
 yarn serve --port=8085 --host 0.0.0.0

 ...

 Your application is ready~! 🚀

  ➡ Port 8080,8085 is taken; using 37543 instead

  - Local:      http://0.0.0.0:37543
  - Network:    http://192.168.2.2:37543

────────────────── LOGS ──────────────────
```

It doesn't matter what port I pick.

This PR drops 8080 from package.json which makes the above issue go away. By default it still picks port 8080.
