### PR TITLE
Support international hashtags

### DIFF
--- a/src/js/Helpers.tsx
+++ b/src/js/Helpers.tsx
@@ -23,7 +23,7 @@ const noteRegex =
   /(?:^|\s|nostr:|(?:https?:\/\/[\w./]+)|iris\.to\/|snort\.social\/e\/|damus\.io\/)+((?:@)?note[a-zA-Z0-9]{59,60})(?![\w/])/gi;
 const nip19Regex = /\bnostr:(n(?:event|profile)1\w+)\b/g;
 
-const hashtagRegex = /(#\w+)/g;
+const hashtagRegex = /(#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)/g;
 
 let settings: any = {};
 localState.get('settings').on((s) => (settings = s));


### PR DESCRIPTION
## Problem:
Not all international hashtags are rendering properly on Iris today (Both in profile description and also in note content).

## Screenshots with problem:
Visit the profile with NIP-05 ID - vivganes@vivekganesan.com
![image](https://github.com/irislib/iris-messenger/assets/2035886/af3784d3-0173-42be-86ba-a76c76e5e72f)

Visit the note at URL - https://iris.to/note1lzeujaaaqlqju6vdg7su3w73h5uv2v4zw65rxlgjccwdm6wq9qusfh8czp 
![image](https://github.com/irislib/iris-messenger/assets/2035886/5a7bd32a-0c71-4ed9-974c-14e9b2085d1b)

Note that intl hashtags are not rendered.

## Root cause:
It is due to regex looking for only english chars, numbers and _

## Solution:
Use a blacklist instead of whitelist to look for hashtags (much like the solution here: https://stackoverflow.com/a/27343333)

## Screenshots after the fix:
![image](https://github.com/irislib/iris-messenger/assets/2035886/d24322a3-e954-4a7f-9e09-3156b2a5f5b1)
![image](https://github.com/irislib/iris-messenger/assets/2035886/d46c112d-9f0f-4b3a-aae1-a3a116e6cc9a)

## Additional context
Similar PRs have been accepted in other clients (snort and amethyst)

