### PR TITLE
Added ability to scroll feed with J and K keys

### DIFF
--- a/src/js/components/feed/BaseFeed.tsx
+++ b/src/js/components/feed/BaseFeed.tsx
@@ -135,14 +135,32 @@ class Feed extends BaseComponent<FeedProps, FeedState> {
     }
   };
 
+  handleScrollKeys = (e) => {
+    const name = e.key;
+    if (name === 'j')
+      window.scrollBy({
+        top: document.documentElement.clientHeight / 2,
+        left: 0,
+        behavior: 'smooth',
+      });
+    if (name === 'k')
+      window.scrollBy({
+        top: -document.documentElement.clientHeight / 2,
+        left: 0,
+        behavior: 'smooth',
+      });
+  };
+
   componentWillUnmount() {
     super.componentWillUnmount();
     window.removeEventListener('scroll', this.handleScroll);
+    window.removeEventListener('keyup', this.handleScrollKeys);
     this.unsub && this.unsub();
   }
 
   componentDidMount() {
     window.addEventListener('scroll', this.handleScroll);
+    window.addEventListener('keyup', this.handleScrollKeys);
     this.subscribe();
     if (isEqual(this.state.settings, DEFAULT_SETTINGS)) {
       // no settings saved in history state, load from localstorage


### PR DESCRIPTION
HJKL keys can be used for scrolling on certain social networks like Facebook, Twitter, or 9GAG, providing a quick way to navigate through feeds or timelines. Over time, the HJKL keys found their way into other applications and environments, particularly those that aimed to provide Vim-like keybindings or cater to Vim users. This includes various text editors, command-line interfaces, and even certain web-based applications.

I implemented simple scrolling with J and K keys for iris