### PR TITLE
Fix: make network relay usable on mobile

### DIFF
--- a/src/js/views/settings/Network.tsx
+++ b/src/js/views/settings/Network.tsx
@@ -72,7 +72,7 @@ const Network = () => {
       <div className="flex flex-col gap-2">
         {relays.map((relay) => (
           <div className="flex gap-2 flex-row peer">
-            <div className="flex-1" key={relay.url}>
+            <div className="flex-1 truncate" key={relay.url}>
               <span className={getClassName(relay)}>&#x2B24; </span>
               {relay.url}
             </div>

--- a/src/js/views/settings/Network.tsx
+++ b/src/js/views/settings/Network.tsx
@@ -72,7 +72,7 @@ const Network = () => {
       <div className="flex flex-col gap-2">
         {relays.map((relay) => (
           <div className="flex gap-2 flex-row peer">
-            <div className="flex-1 truncate" key={relay.url}>
+            <div className="flex-1 truncate max-w-[60vw]" key={relay.url}>
               <span className={getClassName(relay)}>&#x2B24; </span>
               {relay.url}
             </div>
@@ -125,7 +125,7 @@ const Network = () => {
         {popularRelays.map((relay) => (
           <div className="flex peer gap-2" key={relay.url}>
             <div className="flex-initial">{relay.users}</div>
-            <div className="flex-grow truncate">{relay.url}</div>
+            <div className="flex-grow truncate max-w-[60vw]">{relay.url}</div>
             <div className="flex-initial">
               <button
                 className="btn btn-sm btn-neutral"


### PR DESCRIPTION
This was just bugging me a bit. Happy for any feedback.

## Current issue
- because of one long relay-url the buttons are being pushed out of the visible screen on small screens
- "network"-list entries are now being truncated ("popular"-list entries are being truncated)
<img width="374" alt="image" src="https://github.com/irislib/iris-messenger/assets/1016218/28a36138-533b-4bf7-81d2-e09ac35ca209">
<img width="375" alt="image" src="https://github.com/irislib/iris-messenger/assets/1016218/e554714c-448d-47a8-81d2-b4c2a0213abc">


## This PR tries to solve this by
- add truncate to "network"-entries as well
- add maximum-width to relay-urls
<img width="370" alt="image" src="https://github.com/irislib/iris-messenger/assets/1016218/12352b92-abb5-4b4b-8104-6928f195eac1">
<img width="370" alt="image" src="https://github.com/irislib/iris-messenger/assets/1016218/c8a2c325-e16e-4ebf-9756-584db4c0cfd8">
