### PR TITLE
fix: move close button to top right of modal

### DIFF
--- a/src/js/components/modal/Zap.tsx
+++ b/src/js/components/modal/Zap.tsx
@@ -387,7 +387,7 @@ export default function SendSats(props: ZapProps) {
 
   return (
     <Modal showContainer={true} centerVertically={true} onClose={onClose}>
-      <div className="bg-black rounded-lg p-8 w-[400px] relative">
+      <div className="bg-black rounded-lg p-8 relative">
         <div className="lnurl-tip" onClick={(e) => e.stopPropagation()}>
           <div className="absolute top-2.5 right-2.5 cursor-pointer">
             <XMarkIcon width={20} height={20} />


### PR DESCRIPTION
Move close button to top right of zap modal.

<img width="778" alt="image" src="https://github.com/irislib/iris-messenger/assets/7018802/978e7d22-2d48-4a5d-a9ce-505adcf2a2d6">

After fixed:

<img width="709" alt="image" src="https://github.com/irislib/iris-messenger/assets/7018802/fba0d4d5-e51e-4c42-88dd-894f1bf886ec">
