### PR TITLE
Trim Zap comment

### DIFF
--- a/src/js/components/modal/Zap.tsx
+++ b/src/js/components/modal/Zap.tsx
@@ -165,7 +165,7 @@ export default function SendSats(props: ZapProps) {
         created_at: Math.floor(Date.now() / 1000),
         kind: 9734,
         pubkey: Key.getPubKey(),
-        content: comment || '',
+        content: comment?.trim() || '',
         tags: [
           ['e', note],
           ['p', recipient],


### PR DESCRIPTION
We had a bug when trying to parse the json of a comment. It had a `\n` at the end of it and our browser's json parser couldn't handle it. This should fix